### PR TITLE
Feature/fix url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VitDeckは多人数で特定のルールに沿ったUnityのアセットを同�
 作業管理者が事前にテンプレートおよびチェック用のルールを構成した上で作業者に配布することを前提にしています。
 
 # インストール方法
-[最新のリリース](https://github.com/vkettools/VitDeck/releases/latest)のunitypackageをダウンロードし、VitDeckを使用したいUnityプロジェクトにインポートしてください。
+[最新のリリース](https://github.com/vitdeck/VitDeck/releases/latest)のunitypackageをダウンロードし、VitDeckを使用したいUnityプロジェクトにインポートしてください。
 正しくインポートされるとUnityのメニューバーに`VitDeck`が表示されます。
 
 # 各機能の使い方
@@ -32,10 +32,10 @@ VitDeckは多人数で特定のルールに沿ったUnityのアセットを同�
 
 # ツール構成方法
 VitDeckを配布する前に管理者が各機能を構成する方法は以下を参照してください。
-- [テンプレートの作成方法](https://github.com/vkettools/VitDeck/wiki/MakingTemplate)
-- [ルールセットの作成方法](https://github.com/vkettools/VitDeck/wiki/MakingRuleSet)
-- [エクスポート設定の作成方法](https://github.com/vkettools/VitDeck/wiki/MakingExportSetting)
-- [アップデート通知の構成](https://github.com/vkettools/VitDeck/wiki/ConfiguringUpdateNortification)
+- [テンプレートの作成方法](https://github.com/vitdeck/VitDeck/wiki/MakingTemplate)
+- [ルールセットの作成方法](https://github.com/vitdeck/VitDeck/wiki/MakingRuleSet)
+- [エクスポート設定の作成方法](https://github.com/vitdeck/VitDeck/wiki/MakingExportSetting)
+- [アップデート通知の構成](https://github.com/vitdeck/VitDeck/wiki/ConfiguringUpdateNortification)
 
 # 検証可能なルール
 VitDeckでは検証したいルールの組み合わせとその設定をルールセットと呼ばれる単位で管理します。

--- a/VitDeck/Assets/VitDeck/Config/ProductInfo.asset
+++ b/VitDeck/Assets/VitDeck/Config/ProductInfo.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   version: 1.0.0-dev
   developerLinkTitle: VitDeck on GitHub
-  developerLinkURL: https://github.com/vkettools/VitDeck
+  developerLinkURL: https://github.com/vitdeck/VitDeck

--- a/VitDeck/Assets/VitDeck/Main/Tests/JsonReleaseInfoTest.cs
+++ b/VitDeck/Assets/VitDeck/Main/Tests/JsonReleaseInfoTest.cs
@@ -7,12 +7,12 @@ namespace VitDeck.Main.Tests
         [Test]
         public void TestJsonReleaseInfo()
         {
-            string testJsonURL = "https://vkettools.github.io/VitDeckTest/releases/latest.json";
+            string testJsonURL = "https://vitdeck.github.io/VitDeckTest/releases/latest.json";
             JsonReleaseInfo.FetchInfo(testJsonURL);
             Assert.That(JsonReleaseInfo.GetVersion(), Is.EqualTo("1.0.0"));
             Assert.That(JsonReleaseInfo.GetPackageName(), Is.EqualTo("VitDeck-1.0.0-alpha1.unitypackage"));
             Assert.That(JsonReleaseInfo.GetDownloadURL(),
-                Is.EqualTo("https://github.com/vkettools/VitDeckTest/releases/download/1.0.0-alpha1/VitDeck-1.0.0-alpha1.unitypackage"));
+                Is.EqualTo("https://github.com/vitdeck/VitDeckTest/releases/download/1.0.0-alpha1/VitDeck-1.0.0-alpha1.unitypackage"));
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Main/Tests/UpdateCheckTest.cs
+++ b/VitDeck/Assets/VitDeck/Main/Tests/UpdateCheckTest.cs
@@ -5,7 +5,7 @@ namespace VitDeck.Main.Tests
 {
     public class UpdateCheckTest
     {
-        private static readonly string testURL = "https://vkettools.github.io/VitDeckTest/releases/latest.json";
+        private static readonly string testURL = "https://vitdeck.github.io/VitDeckTest/releases/latest.json";
 
         [Test]
         public void TestLatestVersioning()

--- a/VitDeck/Assets/VitDeck/TemplateLoader/Tests/TemplateLoaderTest.cs
+++ b/VitDeck/Assets/VitDeck/TemplateLoader/Tests/TemplateLoaderTest.cs
@@ -72,7 +72,7 @@ namespace VitDeck.TemplateLoader.Test
             Assert.That(TemplateLoader.GetTemplateProperty("Sample_template").templateName, Is.EqualTo("Sample Template"));
             Assert.That(TemplateLoader.GetTemplateProperty("Sample_template").description, Is.EqualTo("This is VitDeck sample template"));
             Assert.That(TemplateLoader.GetTemplateProperty("Sample_template").developer, Is.EqualTo("VitDeck"));
-            Assert.That(TemplateLoader.GetTemplateProperty("Sample_template").developerUrl, Is.EqualTo("https://github.com/vkettools/VitDeck"));
+            Assert.That(TemplateLoader.GetTemplateProperty("Sample_template").developerUrl, Is.EqualTo("https://github.com/vitdeck/VitDeck"));
             Assert.That(TemplateLoader.GetTemplateProperty("Sample_template").lisenseFile.name, Is.EqualTo("LICENSE"));
         }
         [TearDown]

--- a/VitDeck/Assets/VitDeck/Templates/Sample_template/Property.asset
+++ b/VitDeck/Assets/VitDeck/Templates/Sample_template/Property.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   description: This is VitDeck sample template
   lisenseFile: {fileID: 4900000, guid: 2c5e4f38eb7e35447b696a1c5229aaff, type: 3}
   developer: VitDeck
-  developerUrl: https://github.com/vkettools/VitDeck
+  developerUrl: https://github.com/vitdeck/VitDeck
   replaceList:
   - ID: BOOTHID
     searchString: BOOTHID

--- a/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs
@@ -9,6 +9,6 @@ namespace VitDeck.Utilities
         [SerializeField]
         public string developerLinkTitle = "VitDeck on GitHub";
         [SerializeField]
-        public string developerLinkURL = "https://github.com/vkettools/VitDeck";
+        public string developerLinkURL = "https://github.com/vitdeck/VitDeck";
     }
 }

--- a/VitDeck/Assets/VitDeck/Utilities/Tests/ProductInfoUtilityTest.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/Tests/ProductInfoUtilityTest.cs
@@ -20,7 +20,7 @@ namespace VitDeck.Utilities.Tests
         public void TestGetDeveloperLinkURL()
         {
             var url = ProductInfoUtility.GetDeveloperLinkURL();
-            Assert.That(url, Is.EqualTo("https://github.com/vkettools/VitDeck"));
+            Assert.That(url, Is.EqualTo("https://github.com/vitdeck/VitDeck"));
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Utilities/Tests/URLUtilityTest.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/Tests/URLUtilityTest.cs
@@ -7,8 +7,8 @@ namespace VitDeck.Utilities.Tests
         [Test]
         public void TestIsValidURL()
         {
-            Assert.That(URLUtility.isValidURLString("http://github.com/vkettools/VitDeck"), Is.True);
-            Assert.That(URLUtility.isValidURLString("https://github.com/vkettools/VitDeck/blob/56b11a7dbbca3b8cf6c4104ca443f78f2beae9c1/LICENSE?query=test#1"), Is.True);
+            Assert.That(URLUtility.isValidURLString("http://github.com/vitdeck/VitDeck"), Is.True);
+            Assert.That(URLUtility.isValidURLString("https://github.com/vitdeck/VitDeck/blob/56b11a7dbbca3b8cf6c4104ca443f78f2beae9c1/LICENSE?query=test#1"), Is.True);
             Assert.That(URLUtility.isValidURLString("http://www.google.co.jp/search?q=C"), Is.True);
             Assert.That(URLUtility.isValidURLString("ftp://github.com/"), Is.False);
             Assert.That(URLUtility.isValidURLString(""), Is.False);

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Sample/SampleRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Sample/SampleRule.cs
@@ -22,13 +22,13 @@ namespace VitDeck.Validator
             //チェック結果を設定
             var baseFolder = AssetDatabase.LoadAssetAtPath<DefaultAsset>(target.GetBaseFolderPath());
             AddIssue(new Issue(baseFolder, IssueLevel.Info, "これはtargetを設定したサンプルルールの検証結果です。target:" + baseFolder.name));
-            AddIssue(new Issue(null, IssueLevel.Info, "これはサンプルルールの解決策付き検証結果（情報）です。", "解決策テキスト", "https://github.com/vkettools/VitDeck/wiki"));
+            AddIssue(new Issue(null, IssueLevel.Info, "これはサンプルルールの解決策付き検証結果（情報）です。", "解決策テキスト", "https://github.com/vitdeck/VitDeck/wiki"));
             var items = "";
 
             for (int i = 0; i < 10; i++)
                 items += "- item" + Environment.NewLine;
-            AddIssue(new Issue(null, IssueLevel.Warning, "これはサンプルルールの改行の多い検証結果(警告)です。" + Environment.NewLine + items, "解決策テキスト", "https://github.com/vkettools/VitDeck/wiki"));
-            AddIssue(new Issue(null, IssueLevel.Error, "これはサンプルルールの検証結果(エラー)です。長い文------------------------------------------------------------章", "解決策テキスト", "https://github.com/vkettools/VitDeck/wiki"));
+            AddIssue(new Issue(null, IssueLevel.Warning, "これはサンプルルールの改行の多い検証結果(警告)です。" + Environment.NewLine + items, "解決策テキスト", "https://github.com/vitdeck/VitDeck/wiki"));
+            AddIssue(new Issue(null, IssueLevel.Error, "これはサンプルルールの検証結果(エラー)です。長い文------------------------------------------------------------章", "解決策テキスト", "https://github.com/vitdeck/VitDeck/wiki"));
 
             AddResultLog("Ruleのissueに紐付かないログです。customSetting：" + customSetting);
         }

--- a/release.bat
+++ b/release.bat
@@ -51,7 +51,7 @@ echo Generate json file >> "%BAT_LOG%" 2>&1
 echo { > %RELEASE_INFO_JSON% 2>&1
 echo  "version": "%VERSION%", >> %RELEASE_INFO_JSON% 2>&1
 echo  "package_name": "VitDeck-%VERSION%.unitypackage", >> %RELEASE_INFO_JSON% 2>&1
-echo  "download_url": "https://github.com/vkettools/VitDeck/releases/download/%VERSION%/VitDeck-%VERSION%.unitypackage" >> %RELEASE_INFO_JSON% 2>&1
+echo  "download_url": "https://github.com/vitdeck/VitDeck/releases/download/%VERSION%/VitDeck-%VERSION%.unitypackage" >> %RELEASE_INFO_JSON% 2>&1
 echo } >> %RELEASE_INFO_JSON% 2>&1
 
 echo Move to Release folder >> "%BAT_LOG%" 2>&1


### PR DESCRIPTION
Organization名変更に伴うURL変更（vkettools → vitdeck）です。

テキストGrepで全箇所を確認・変更後にTestRunnerと目視で修正確認しています。

この変更以降、過去のコードでTestRunnerの`JsonReleaseInfoTest`は通らなくなります。
（テストリポジトリの中身も変更したため）

お手数ですが今後の作業前に一度最新のdevelopをpullお願いします。